### PR TITLE
[WIP] Implement CI on Gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,18 @@
+variables:
+    CI_IMAGE_TAG: "opengl"
+    MODERNGL_DEBUGGING: "true"
+    JULIA_DEPOT_PATH: "$CI_PROJECT_DIR/.julia/"
+
+job:
+    image: "juliagpu/julia:v1.0-${CI_IMAGE_TAG}"
+    before_script:
+        - apt-get -qq update
+        # glfw
+        - apt-get install -y cmake libxrandr-dev libxinerama-dev libxcursor-dev mesa-utils
+        # cairo etc
+        - apt-get install -y gettext libpango1.0-0 libcairo2 libmagickwand-6.q16
+        - apt-get install -y ffmpeg
+
+    script:
+      - julia -e 'using InteractiveUtils; versioninfo()'
+      - julia -e 'using Pkg; Pkg.instantiate(); Pkg.add(PackageSpec(name = "MakieThemes", path=ENV["CI_PROJECT_DIR"])); Pkg.test("MakieThemes")'


### PR DESCRIPTION
Creates a Gitlab CI template for CI on MakieGallery.

Requires MakieGallery to be mirrored to Gitlab first.